### PR TITLE
Hide captions in traceability matrix

### DIFF
--- a/mlx/xunit2rst.mako
+++ b/mlx/xunit2rst.mako
@@ -55,3 +55,4 @@ The below table traces the test report to test cases.
     :type: fails passes
     :stats:
     :group:
+    :nocaptions:

--- a/tests/test_in/itest_lin_report.rst
+++ b/tests/test_in/itest_lin_report.rst
@@ -37,3 +37,4 @@ The below table traces the test report to test cases.
     :type: fails passes
     :stats:
     :group:
+    :nocaptions:

--- a/tests/test_in/itest_report.rst
+++ b/tests/test_in/itest_report.rst
@@ -37,3 +37,4 @@ The below table traces the test report to test cases.
     :type: fails passes
     :stats:
     :group:
+    :nocaptions:


### PR DESCRIPTION
Since the captions of the test report items aren't useful in the traceability matrix and the item IDs can get very long, which can result in cell overflow in PDF, I suggest that the captions in the traceability matrix become hidden. They can still be shown on hover of cursor in HTML.

I'm not sure if a flag to show these captions is wanted?