### PR TITLE
Improve and test error handling of Mako template

### DIFF
--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -24,7 +24,8 @@ def render_template(destination, **kwargs):
         **kwargs (dict): Variables to be used in the Mako template.
 
     Raises:
-        ERROR: Error is raised by Mako template.
+        ERROR: Error log containing information about the line where the exception occurred.
+        Exception: Re-raised Exception coming from Mako template.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
     with open(str(destination), 'w', newline='\n') as rst_file:

--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -31,12 +31,11 @@ def render_template(destination, **kwargs):
         template = Template(filename=str(TEMPLATE_FILE), output_encoding='utf-8', input_encoding='utf-8')
         try:
             template.render_context(Context(rst_file, **kwargs))
-        except OSError:
+        except Exception as exc:
             traceback = RichTraceback()
-            for (filename, lineno, function, line) in traceback.traceback:
-                logging.error("File %s, line %s, in %s", filename, lineno, function)
-                logging.error(line, "\n")
-            logging.error("%s: %s", str(traceback.error.__class__.__name__), traceback.error)
+            logging.error("Exception raised in Mako template, which will be re-raised after logging line info:")
+            logging.error("File %s, line %s, in %s: %r", *traceback.traceback[-1])
+            raise exc
 
 
 def generate_xunit_to_rst(input_file, rst_file, prefix, trim_suffix, itemize_suites, unit_or_integration):


### PR DESCRIPTION
Example of error log + exception raised:
```
root: ERROR: Exception raised in Mako template:
root: ERROR: File C:\Users\jce\projects\git\xunit2rst\mlx\xunit2rst.mako, line 25, in render_body: '% for suite in test_suites:'
TypeError: 'Undefined' object is not iterable
```

Used as target by #9 and #10 