### PR TITLE
Refactor code that determines prefix and prefix_set variables

### DIFF
--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -133,8 +133,8 @@ def verify_prefix_set(prefix_set, prefix, unit_or_integration):
     integration test report otherwise.
 
     Args:
-        prefix_set (TraceableInfo): TraceableInfo UTEST or ITEST decided by the presence or lack of a 'testsuites'
-            element as root.
+        prefix_set (TraceableInfo): TraceableInfo UTEST or ITEST decided by the presence or lack of a root element
+            'testsuites'.
         prefix (str): Prefix that will be used in the Mako template.
         unit_or_integration (None/str): None if the script's discernment shall be used, otherwise a string starting
             with 'u' or 'i', indicating unit test report or integration test report respectively as input.

--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -62,12 +62,14 @@ def generate_xunit_to_rst(input_file, rst_file, prefix, trim_suffix, itemize_sui
         if len(item_name_halves) > 1:
             prefix = item_name_halves[0] + '-'
         else:  # no prefix in name
-            prefix = prefix_set.matrix_prefix.replace('_', '-')
+            prefix = prefix_set.matrix_prefix
             base_prefix_on_set = True
 
     prefix_set = _verify_prefix_set(prefix_set, unit_or_integration, prefix)
     if base_prefix_on_set:
-        prefix = prefix_set.matrix_prefix.replace('_', '-')
+        prefix = prefix_set.matrix_prefix
+    prefix = prefix.rstrip('_')
+    prefix = prefix + '-' if not prefix.endswith('-') else prefix
 
     report_name = rst_file.stem
     if report_name.endswith('_report'):

--- a/tests/acceptance_test.py
+++ b/tests/acceptance_test.py
@@ -174,5 +174,18 @@ def test_junit_prefix():
     assert filecmp.cmp(output_rst, reference_rst)
 
 
+@with_setup(setup)
+def test_junit_override_xml_prefix():
+    '''Tests based on utest reports in JUnit format - adding prefix via input arg'''
+    rst_file_name = '{}.rst'.format('utest_override_prefix_report')
+    xml_file_name = '{}.xml'.format('utest_my_lib_report')
+    input_xml = str(TEST_IN_DIR / xml_file_name)
+    output_rst = str(TEST_OUT_DIR / rst_file_name)
+    xunit2rst_check(input_xml, output_rst, prefix='OVERRIDING-')
+
+    reference_rst = str(TEST_IN_DIR / rst_file_name)
+    assert filecmp.cmp(output_rst, reference_rst)
+
+
 if __name__ == '__main__':
     nose.main()

--- a/tests/acceptance_test.py
+++ b/tests/acceptance_test.py
@@ -6,12 +6,11 @@ outputs of the tool match the reference output files exactly.
 '''
 import filecmp
 from pathlib import Path
-from unittest import TestCase
 
 import nose
-from nose.tools import with_setup, assert_equals, assert_raises
+from nose.tools import with_setup
 
-from mlx.xunit2rst import create_parser, generate_xunit_to_rst, render_template, _verify_prefix_set, ITEST, UTEST
+from mlx.xunit2rst import create_parser, generate_xunit_to_rst
 
 TOP_DIR = Path(__file__).parents[1]
 TEST_OUT_DIR = Path(__file__).parent / 'test_out'
@@ -45,9 +44,9 @@ def xunit2rst_check(input_xml, output_rst, itemize_suites=False, prefix='', trim
     generate_xunit_to_rst(
         args.input_file,
         args.rst_output_file,
+        args.itemize_suites,
         args.prefix,
         args.trim_suffix,
-        args.itemize_suites,
         args.unit_or_integration,
     )
 
@@ -173,49 +172,6 @@ def test_junit_prefix():
 
     reference_rst = str(TEST_IN_DIR / rst_file_name)
     assert filecmp.cmp(output_rst, reference_rst)
-
-
-@with_setup(setup)
-def mako_error_handling_test():
-    ''' Tests error logging and re-raising of an Exception in Mako template by intentionally not passing a variable '''
-    kwargs = {
-        'report_name': 'my_report',
-        'info': ITEST,
-        'prefix': 'MAKO_TEST-',
-    }
-    test_case = TestCase()
-    with test_case.assertLogs() as log_cm:
-        with assert_raises(TypeError):
-            render_template((TEST_OUT_DIR / 'never_created_file.rst'), **kwargs)
-    test_case.assertIn('Exception raised in Mako template, which will be re-raised after logging line info:',
-                       log_cm.output[0])
-    test_case.assertIn('File ', log_cm.output[-1])
-    test_case.assertIn('line ', log_cm.output[-1])
-    test_case.assertIn("in render_body: '% for suite in test_suites:'", log_cm.output[-1])
-
-
-def verify_prefix_set_u_or_i_test():
-    '''
-    Tests _verify_prefix_set function. The unit_or_integration argument should have the highest priority and must
-    start with u or i (case-insensitive). The prefix argument has the second highest priority. A last resort is to
-    keep the input prefix_set.
-    '''
-    assert_equals(_verify_prefix_set(UTEST, 'Itest', 'UTEST-'), ITEST)
-    assert_equals(_verify_prefix_set(UTEST, 'i', 'UTEST-'), ITEST)
-    assert_equals(_verify_prefix_set(UTEST, 'i', ''), ITEST)
-    assert_equals(_verify_prefix_set(ITEST, 'Utest', 'ITEST-'), UTEST)
-    assert_equals(_verify_prefix_set(UTEST, 'u', 'ITEST-'), UTEST)
-    assert_equals(_verify_prefix_set(UTEST, 'u', 'UTEST-'), UTEST)
-    assert_equals(_verify_prefix_set(UTEST, None, 'BLAH-'), UTEST)
-    assert_equals(_verify_prefix_set(ITEST, None, 'BLAH-'), ITEST)
-    assert_equals(_verify_prefix_set(UTEST, None, 'ITEST-'), ITEST)
-    assert_equals(_verify_prefix_set(ITEST, None, 'UTEST-'), UTEST)
-    with assert_raises(ValueError):
-        _verify_prefix_set(UTEST, 't', 'UTEST-')
-    with assert_raises(ValueError):
-        _verify_prefix_set(ITEST, 't', 'ITEST')
-    with assert_raises(ValueError):
-        _verify_prefix_set(ITEST, 't', '')
 
 
 if __name__ == '__main__':

--- a/tests/mako_test.py
+++ b/tests/mako_test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+''' Test suite for error handling for Mako template '''
+from unittest import TestCase
+from pathlib import Path
+from nose.tools import assert_raises
+from mlx.xunit2rst import render_template, ITEST
+
+TEST_OUT_DIR = Path(__file__).parent / 'test_out'
+
+
+def test_mako_error_handling():
+    ''' Tests error logging and re-raising of an Exception in Mako template by intentionally not passing a variable '''
+    kwargs = {
+        'report_name': 'my_report',
+        'info': ITEST,
+        'prefix': 'MAKO_TEST-',
+    }
+    test_case = TestCase()
+    with test_case.assertLogs() as log_cm:
+        with assert_raises(TypeError):
+            render_template((TEST_OUT_DIR / 'never_created_file.rst'), **kwargs)
+    test_case.assertIn('Exception raised in Mako template, which will be re-raised after logging line info:',
+                       log_cm.output[0])
+    test_case.assertIn('File ', log_cm.output[-1])
+    test_case.assertIn('line ', log_cm.output[-1])
+    test_case.assertIn("in render_body: '% for suite in test_suites:'", log_cm.output[-1])

--- a/tests/prefix_test.py
+++ b/tests/prefix_test.py
@@ -1,13 +1,76 @@
-import xml.etree.ElementTree as ET
+from pathlib import Path
 
 import nose
-from nose.tools import assert_equals, assert_raises
+from nose.tools import assert_equals, assert_not_equals, assert_raises
 
-from mlx.xunit2rst import build_prefix_and_set, verify_prefix_set, ITEST, UTEST
+from mlx.xunit2rst import build_prefix_and_set, parse_xunit_root, verify_prefix_set, ITEST, UTEST
+
+TEST_IN_DIR = Path(__file__).parent / 'test_in'
 
 
-def build_prefix_and_set_test():
-    pass
+def build_prefix_and_set_utest_default_test():
+    ''' Use default prefix for unit test reports '''
+    test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'utest_my_lib_no_prefix_report.xml')
+    assert_equals(initial_prefix_set, UTEST)
+
+    prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, '', True, None)
+    assert_equals(prefix_set, initial_prefix_set)
+    assert_equals(prefix, 'UTEST-')
+
+
+def build_prefix_and_set_itest_default_test():
+    ''' Use default prefix for integration test reports '''
+    test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'itest_report.xml')
+    assert_equals(initial_prefix_set, ITEST)
+
+    prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, '', True, None)
+    assert_equals(prefix_set, initial_prefix_set)
+    assert_equals(prefix, 'ITEST-')
+
+
+def build_prefix_and_set_from_name_test():
+    ''' Get prefix from element name '''
+    test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'utest_my_lib_report.xml')
+    assert_equals(initial_prefix_set, UTEST)
+
+    prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, '', True, None)
+    assert_equals(prefix_set, initial_prefix_set)
+    assert_equals(prefix, 'UTEST_MY_LIB-')
+
+
+def build_prefix_and_set_from_arg_test():
+    ''' Get prefix from input argument `--prefix` and trim suffix of prefix '''
+    test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'utest_my_lib_report.xml')
+    assert_equals(initial_prefix_set, UTEST)
+
+    prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, 'TEST_MY_LIB_-', True, None)
+    assert_equals(prefix_set, initial_prefix_set)
+    assert_equals(prefix, 'TEST_MY_LIB-')
+
+
+def build_prefix_and_set_from_arg_swap_set_test():
+    '''
+    Get prefix from input argument `--prefix` and base prefix_set on its first letter.
+    Don't trim suffix of prefix.
+    '''
+    test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'itest_report.xml')
+    assert_equals(initial_prefix_set, ITEST)
+
+    prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, 'UTEST_MY_LIB_-', False, None)
+    assert_not_equals(prefix_set, initial_prefix_set)
+    assert_equals(prefix_set, UTEST)
+    assert_equals(prefix, 'UTEST_MY_LIB_-')
+
+
+def build_prefix_and_set_priority_test():
+    ''' Argument unit_or_integration must have the highest priority for determining the correct prefix_set. '''
+    test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'utest_my_lib_report.xml')
+    assert_equals(initial_prefix_set, UTEST)
+
+    prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, 'UTEST_HOWDY-', False, 'i')
+    assert_not_equals(prefix_set, initial_prefix_set)
+    assert_equals(prefix_set, ITEST)
+    assert_equals(prefix, 'UTEST_HOWDY-')
 
 
 def verify_prefix_set_u_or_i_test():

--- a/tests/prefix_test.py
+++ b/tests/prefix_test.py
@@ -1,0 +1,38 @@
+import xml.etree.ElementTree as ET
+
+import nose
+from nose.tools import assert_equals, assert_raises
+
+from mlx.xunit2rst import build_prefix_and_set, verify_prefix_set, ITEST, UTEST
+
+
+def build_prefix_and_set_test():
+    pass
+
+
+def verify_prefix_set_u_or_i_test():
+    '''
+    Tests verify_prefix_set function. The unit_or_integration argument should have the highest priority and must
+    start with u or i (case-insensitive). The prefix argument has the second highest priority. A last resort is to
+    keep the input prefix_set.
+    '''
+    assert_equals(verify_prefix_set(UTEST, 'UTEST-', 'Itest'), ITEST)
+    assert_equals(verify_prefix_set(UTEST, 'UTEST-', 'i'), ITEST)
+    assert_equals(verify_prefix_set(UTEST, '', 'i'), ITEST)
+    assert_equals(verify_prefix_set(ITEST, 'ITEST-', 'Utest'), UTEST)
+    assert_equals(verify_prefix_set(UTEST, 'ITEST-', 'u'), UTEST)
+    assert_equals(verify_prefix_set(UTEST, 'UTEST-', 'u'), UTEST)
+    assert_equals(verify_prefix_set(UTEST, 'BLAH-', None), UTEST)
+    assert_equals(verify_prefix_set(ITEST, 'BLAH-', None), ITEST)
+    assert_equals(verify_prefix_set(UTEST, 'ITEST-', None), ITEST)
+    assert_equals(verify_prefix_set(ITEST, 'UTEST-', None), UTEST)
+    with assert_raises(ValueError):
+        verify_prefix_set(UTEST, 'UTEST-', 't')
+    with assert_raises(ValueError):
+        verify_prefix_set(ITEST, 'ITEST', 't')
+    with assert_raises(ValueError):
+        verify_prefix_set(ITEST, '', 't')
+
+
+if __name__ == '__main__':
+    nose.main()

--- a/tests/prefix_test.py
+++ b/tests/prefix_test.py
@@ -1,94 +1,96 @@
+#!/usr/bin/env python3
+''' Test suite for functions that set the prefix and prefix_set variables '''
 from pathlib import Path
 
 import nose
-from nose.tools import assert_equals, assert_not_equals, assert_raises
+from nose.tools import assert_equal, assert_not_equal, assert_raises
 
 from mlx.xunit2rst import build_prefix_and_set, parse_xunit_root, verify_prefix_set, ITEST, UTEST
 
 TEST_IN_DIR = Path(__file__).parent / 'test_in'
 
 
-def build_prefix_and_set_utest_default_test():
+def test_build_prefix_and_set_utest_default():
     ''' Use default prefix for unit test reports '''
     test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'utest_my_lib_no_prefix_report.xml')
-    assert_equals(initial_prefix_set, UTEST)
+    assert_equal(initial_prefix_set, UTEST)
 
     prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, '', True, None)
-    assert_equals(prefix_set, initial_prefix_set)
-    assert_equals(prefix, 'UTEST-')
+    assert_equal(prefix_set, initial_prefix_set)
+    assert_equal(prefix, 'UTEST-')
 
 
-def build_prefix_and_set_itest_default_test():
+def test_build_prefix_and_set_itest_default():
     ''' Use default prefix for integration test reports '''
     test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'itest_report.xml')
-    assert_equals(initial_prefix_set, ITEST)
+    assert_equal(initial_prefix_set, ITEST)
 
     prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, '', True, None)
-    assert_equals(prefix_set, initial_prefix_set)
-    assert_equals(prefix, 'ITEST-')
+    assert_equal(prefix_set, initial_prefix_set)
+    assert_equal(prefix, 'ITEST-')
 
 
-def build_prefix_and_set_from_name_test():
+def test_build_prefix_and_set_from_name():
     ''' Get prefix from element name '''
     test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'utest_my_lib_report.xml')
-    assert_equals(initial_prefix_set, UTEST)
+    assert_equal(initial_prefix_set, UTEST)
 
     prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, '', True, None)
-    assert_equals(prefix_set, initial_prefix_set)
-    assert_equals(prefix, 'UTEST_MY_LIB-')
+    assert_equal(prefix_set, initial_prefix_set)
+    assert_equal(prefix, 'UTEST_MY_LIB-')
 
 
-def build_prefix_and_set_from_arg_test():
+def test_build_prefix_and_set_from_arg():
     ''' Get prefix from input argument `--prefix` and trim suffix of prefix '''
     test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'utest_my_lib_report.xml')
-    assert_equals(initial_prefix_set, UTEST)
+    assert_equal(initial_prefix_set, UTEST)
 
     prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, 'TEST_MY_LIB_-', True, None)
-    assert_equals(prefix_set, initial_prefix_set)
-    assert_equals(prefix, 'TEST_MY_LIB-')
+    assert_equal(prefix_set, initial_prefix_set)
+    assert_equal(prefix, 'TEST_MY_LIB-')
 
 
-def build_prefix_and_set_from_arg_swap_set_test():
+def test_build_prefix_and_set_from_arg_swap_set():
     '''
     Get prefix from input argument `--prefix` and base prefix_set on its first letter.
     Don't trim suffix of prefix.
     '''
     test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'itest_report.xml')
-    assert_equals(initial_prefix_set, ITEST)
+    assert_equal(initial_prefix_set, ITEST)
 
     prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, 'UTEST_MY_LIB_-', False, None)
-    assert_not_equals(prefix_set, initial_prefix_set)
-    assert_equals(prefix_set, UTEST)
-    assert_equals(prefix, 'UTEST_MY_LIB_-')
+    assert_not_equal(prefix_set, initial_prefix_set)
+    assert_equal(prefix_set, UTEST)
+    assert_equal(prefix, 'UTEST_MY_LIB_-')
 
 
-def build_prefix_and_set_priority_test():
+def test_build_prefix_and_set_priority():
     ''' Argument unit_or_integration must have the highest priority for determining the correct prefix_set. '''
     test_suites, initial_prefix_set = parse_xunit_root(TEST_IN_DIR / 'utest_my_lib_report.xml')
-    assert_equals(initial_prefix_set, UTEST)
+    assert_equal(initial_prefix_set, UTEST)
 
     prefix_set, prefix = build_prefix_and_set(test_suites, initial_prefix_set, 'UTEST_HOWDY-', False, 'i')
-    assert_not_equals(prefix_set, initial_prefix_set)
-    assert_equals(prefix_set, ITEST)
-    assert_equals(prefix, 'UTEST_HOWDY-')
+    assert_not_equal(prefix_set, initial_prefix_set)
+    assert_equal(prefix_set, ITEST)
+    assert_equal(prefix, 'UTEST_HOWDY-')
 
 
-def verify_prefix_set_u_or_i_test():
+def test_verify_prefix_set_u_or_i():
     '''
     Tests verify_prefix_set function. The unit_or_integration argument should have the highest priority and must
     start with u or i (case-insensitive). The prefix argument has the second highest priority. A last resort is to
     keep the input prefix_set.
     '''
-    assert_equals(verify_prefix_set(UTEST, 'UTEST-', 'Itest'), ITEST)
-    assert_equals(verify_prefix_set(UTEST, 'UTEST-', 'i'), ITEST)
-    assert_equals(verify_prefix_set(UTEST, '', 'i'), ITEST)
-    assert_equals(verify_prefix_set(ITEST, 'ITEST-', 'Utest'), UTEST)
-    assert_equals(verify_prefix_set(UTEST, 'ITEST-', 'u'), UTEST)
-    assert_equals(verify_prefix_set(UTEST, 'UTEST-', 'u'), UTEST)
-    assert_equals(verify_prefix_set(UTEST, 'BLAH-', None), UTEST)
-    assert_equals(verify_prefix_set(ITEST, 'BLAH-', None), ITEST)
-    assert_equals(verify_prefix_set(UTEST, 'ITEST-', None), ITEST)
-    assert_equals(verify_prefix_set(ITEST, 'UTEST-', None), UTEST)
+    assert_equal(verify_prefix_set(UTEST, 'UTEST-', 'Itest'), ITEST)
+    assert_equal(verify_prefix_set(UTEST, 'UTEST-', 'i'), ITEST)
+    assert_equal(verify_prefix_set(UTEST, '', 'i'), ITEST)
+    assert_equal(verify_prefix_set(ITEST, 'ITEST-', 'Utest'), UTEST)
+    assert_equal(verify_prefix_set(UTEST, 'ITEST-', 'u'), UTEST)
+    assert_equal(verify_prefix_set(UTEST, 'UTEST-', 'u'), UTEST)
+    assert_equal(verify_prefix_set(UTEST, 'BLAH-', None), UTEST)
+    assert_equal(verify_prefix_set(ITEST, 'BLAH-', None), ITEST)
+    assert_equal(verify_prefix_set(UTEST, 'ITEST-', None), ITEST)
+    assert_equal(verify_prefix_set(ITEST, 'UTEST-', None), UTEST)
     with assert_raises(ValueError):
         verify_prefix_set(UTEST, 'UTEST-', 't')
     with assert_raises(ValueError):

--- a/tests/test_in/utest_override_prefix_report.rst
+++ b/tests/test_in/utest_override_prefix_report.rst
@@ -1,0 +1,45 @@
+.. _unit_test_report_utest_override_prefix:
+
+==========================================
+Unit test report for utest_override_prefix
+==========================================
+
+.. contents:: `Contents`
+    :depth: 2
+    :local:
+
+
+.. item:: REPORT_OVERRIDING-UTEST_MY_LIB-MY_FUNCTION_SUCCESS Test report for OVERRIDING-UTEST_MY_LIB-MY_FUNCTION_SUCCESS
+    :passes: OVERRIDING-UTEST_MY_LIB-MY_FUNCTION_SUCCESS
+
+    Test result: Pass
+
+.. item:: REPORT_OVERRIDING-UTEST_MY_LIB-TEST_MY_FUNCTION_NOT_ERASED Test report for OVERRIDING-UTEST_MY_LIB-TEST_MY_FUNCTION_NOT_ERASED
+    :passes: OVERRIDING-UTEST_MY_LIB-TEST_MY_FUNCTION_NOT_ERASED
+
+    Test result: Pass
+
+.. item:: REPORT_OVERRIDING-UTEST_MY_LIB-TEST_MY_FUNCTION_NOT_UNLOCKED Test report for OVERRIDING-UTEST_MY_LIB-TEST_MY_FUNCTION_NOT_UNLOCKED
+    :passes: OVERRIDING-UTEST_MY_LIB-TEST_MY_FUNCTION_NOT_UNLOCKED
+
+    Test result: Pass
+
+.. item:: REPORT_OVERRIDING-UTEST_MY_LIB-SOME_FUNCTION Test report for OVERRIDING-UTEST_MY_LIB-SOME_FUNCTION
+    :fails: OVERRIDING-UTEST_MY_LIB-SOME_FUNCTION
+
+    Test result: Fail
+
+Traceability matrix
+===================
+
+The below table traces the test report to test cases.
+
+.. item-matrix:: Linking these unit test reports to unit test cases
+    :source: REPORT_OVERRIDING-
+    :target: OVERRIDING-
+    :sourcetitle: Unit test report
+    :targettitle: Unit test specification
+    :type: fails passes
+    :stats:
+    :group:
+    :nocaptions:


### PR DESCRIPTION
- Refactored code that determines `prefix` and `prefix_set` variables.
- Added tests for testing more thorougly.
- Split up test suites into three, one of which should only be used for acceptance testing.