### PR TITLE
Set output encoding to UTF-8

### DIFF
--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -28,7 +28,7 @@ def render_template(destination, **kwargs):
         Exception: Re-raised Exception coming from Mako template.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with open(str(destination), 'w', encoding='utf-8') as rst_file:
+    with open(str(destination), 'w', newline='\n') as rst_file:
         template = Template(filename=str(TEMPLATE_FILE), output_encoding='utf-8', input_encoding='utf-8')
         try:
             template.render_context(Context(rst_file, **kwargs))

--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -28,7 +28,7 @@ def render_template(destination, **kwargs):
         Exception: Re-raised Exception coming from Mako template.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with open(str(destination), 'w', newline='\n') as rst_file:
+    with open(str(destination), 'w', newline='\n', encoding='utf-8') as rst_file:
         template = Template(filename=str(TEMPLATE_FILE), output_encoding='utf-8', input_encoding='utf-8')
         try:
             template.render_context(Context(rst_file, **kwargs))

--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -28,7 +28,7 @@ def render_template(destination, **kwargs):
         Exception: Re-raised Exception coming from Mako template.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with open(str(destination), 'w', newline='\n') as rst_file:
+    with open(str(destination), 'w', encoding='utf-8') as rst_file:
         template = Template(filename=str(TEMPLATE_FILE), output_encoding='utf-8', input_encoding='utf-8')
         try:
             template.render_context(Context(rst_file, **kwargs))


### PR DESCRIPTION
While working on different tool, I noticed an issue with the generated output of that tool when the encoding is not explicitly set in the `open()` function. Let's add it to this tool to be sure.