### PR TITLE
Explicitly specify default value for group option of item-matrix

### DIFF
--- a/mlx/xunit2rst.mako
+++ b/mlx/xunit2rst.mako
@@ -89,7 +89,7 @@ The below table traces the test report to test cases.
     :targettitle: ${info.unit_or_integration.capitalize()} test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:
 \
 <%def name="generate_item(test_name, relationship, failure_msg, tests)">\

--- a/tests/test_in/itest_as_utest_report.rst
+++ b/tests/test_in/itest_as_utest_report.rst
@@ -40,5 +40,5 @@ The below table traces the test report to test cases.
     :targettitle: Unit test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tests/test_in/itest_lin_report.rst
+++ b/tests/test_in/itest_lin_report.rst
@@ -40,5 +40,5 @@ The below table traces the test report to test cases.
     :targettitle: Integration test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tests/test_in/itest_lin_report_failures.rst
+++ b/tests/test_in/itest_lin_report_failures.rst
@@ -44,5 +44,5 @@ The below table traces the test report to test cases.
     :targettitle: Integration test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tests/test_in/itest_report.rst
+++ b/tests/test_in/itest_report.rst
@@ -40,5 +40,5 @@ The below table traces the test report to test cases.
     :targettitle: Integration test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tests/test_in/itest_report_log.rst
+++ b/tests/test_in/itest_report_log.rst
@@ -41,5 +41,5 @@ The below table traces the test report to test cases.
     :targettitle: Integration test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tests/test_in/utest_my_lib_report.rst
+++ b/tests/test_in/utest_my_lib_report.rst
@@ -45,5 +45,5 @@ The below table traces the test report to test cases.
     :targettitle: Unit test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tests/test_in/utest_my_lib_report_failures.rst
+++ b/tests/test_in/utest_my_lib_report_failures.rst
@@ -47,5 +47,5 @@ The below table traces the test report to test cases.
     :targettitle: Unit test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tests/test_in/utest_my_lib_suites_report.rst
+++ b/tests/test_in/utest_my_lib_suites_report.rst
@@ -40,5 +40,5 @@ The below table traces the test report to test cases.
     :targettitle: Unit test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tests/test_in/utest_override_prefix_report.rst
+++ b/tests/test_in/utest_override_prefix_report.rst
@@ -45,5 +45,5 @@ The below table traces the test report to test cases.
     :targettitle: Unit test specification
     :type: fails passes
     :stats:
-    :group:
+    :group: top
     :nocaptions:

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps=
     sphinx_rtd_theme
     mlx.traceability >= 4.3.2
     mlx.warnings >= 1.2.0
-    mlx.robot2rst >= 2.1.0
+    mlx.robot2rst >= 2.0.2
 whitelist_externals =
     bash
     make

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps=
     sphinx_rtd_theme
     mlx.traceability >= 4.3.2
     mlx.warnings >= 1.2.0
-    mlx.robot2rst >= 1.0.2
+    mlx.robot2rst >= 2.1.0
 whitelist_externals =
     bash
     make


### PR DESCRIPTION
Explicitly specify default value for group option of item-matrix for compatibility with [mlx.traceability==7.0.0](https://github.com/melexis/sphinx-traceability-extension/releases/tag/v7.0.0).