### PR TITLE
Put failure messages in a literal code block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,6 @@ doc/source/robot/*.xml
 doc/source/robot/*.html
 doc/source/robot/*.log
 doc/source/generated/*.rst
+doc/source/generated/*.html
 doc/_build/
 tests/test_out/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -37,7 +37,7 @@ html: Makefile
 	@$(RM) $(ITEST_PLAN)
 	-@$(ROBOT) --xunit report.xml -d $(ROBOTDIR) $(ROBOTDIR)/example.robot
 	@$(XUNIT2RST) -v
-	@$(XUNIT2RST) -i $(ROBOT_XUNIT) -o $(OUTDIR)/itest_report.rst -p ITEST_- --trim-suffix -l ../$(LOG_FILE)
+	@$(XUNIT2RST) -i $(ROBOT_XUNIT) -o $(OUTDIR)/itest_report.rst -p ITEST_- --trim-suffix -l ../$(LOG_FILE) --failure-message
 	@$(ROBOT2RST) --robot $(ROBOTDIR)/example.robot --rst $(ITEST_PLAN) --tags ^RQT-$
 	@$(ECHO) -n $(LOG_FILE) | xargs -d ' ' -n 1 -I {} $(CP) $(ROBOTDIR)/{} $(OUTDIR)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)

--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -10,7 +10,7 @@ First Test
     [Documentation]    Example of a failing test
     [Tags]             RQT-LOGGING  RQT-DIRECTORY
     Log    ${MESSAGE}
-    My Keyword    /nonexistent
+    My Keyword    /'nonexistent_'  # parsing this string in a failure message results in a Sphinx warning, unless it's in a literal code block
 
 An Unlinked Test
     [Tags]             FUN

--- a/mlx/xunit2rst.mako
+++ b/mlx/xunit2rst.mako
@@ -23,7 +23,7 @@ def generate_body(input_string, error_type=None):
     Returns:
         str: Indented body, which has been word wrapped to not exceed 120 characters
     '''
-    indent = ' ' * 4
+    indent = ' ' * 6
     complete_string = "{}: {}".format(error_type, input_string) if error_type else input_string
     return indent + textwrap.fill(complete_string, 115).replace('\n', '\n' + indent).strip()
 %>\
@@ -97,13 +97,17 @@ The below table traces the test report to test cases.
     :${relationship}: ${test_name}
 
     Test result: ${test_result}
-
-        % if failure_msg:
-            % for test in tests:
-                % for failure in test.iterfind('failure'):
+<% prepend_literal_block = True %>
+% if failure_msg:
+    % for test in tests:
+        % for failure in test.iterfind('failure'):
+            % if prepend_literal_block:
+    ::
+<% prepend_literal_block = False %>
+            % endif
 ${generate_body(failure.get('message'), failure.get('type'))}
 
-                % endfor
-            %endfor
-        % endif
+        % endfor
+    %endfor
+% endif
 </%def>\

--- a/tests/test_in/itest_lin_report_failures.rst
+++ b/tests/test_in/itest_lin_report_failures.rst
@@ -18,9 +18,11 @@ Test Cases
 
     Test result: Fail
 
-    AssertionError: Directory 'C:\nonexistent' does not exist.
+    ::
 
-    Error: Second failure
+      AssertionError: Directory 'C:\nonexistent' does not exist.
+
+      Error: Second failure
 
 .. item:: REPORT_ITEST-AN_UNLINKED_TEST Test report for ITEST-AN_UNLINKED_TEST
     :passes: ITEST-AN_UNLINKED_TEST

--- a/tests/test_in/utest_my_lib_report_failures.rst
+++ b/tests/test_in/utest_my_lib_report_failures.rst
@@ -23,17 +23,21 @@ Test Cases
 
     Test result: Fail
 
-    File: ./unit_test/my_functions.c Line: 49 Message: exp "12 34 56 " was "12 34 99 "  and some more text to test word
-    wrapping at 120 characters.
+    ::
 
-    Another failure message.
+      File: ./unit_test/my_functions.c Line: 49 Message: exp "12 34 56 " was "12 34 99 "  and some more text to test word
+      wrapping at 120 characters.
+
+      Another failure message.
 
 .. item:: REPORT_UTEST-SOME_FUNCTION Test report for UTEST-SOME_FUNCTION
     :fails: UTEST-SOME_FUNCTION
 
     Test result: Fail
 
-    File: ./unit_test/my_functions.c Line: 49 Message: exp "12 34 56 " was "12 34 99 "
+    ::
+
+      File: ./unit_test/my_functions.c Line: 49 Message: exp "12 34 56 " was "12 34 99 "
 
 Traceability Matrix
 ===================

--- a/tox.ini
+++ b/tox.ini
@@ -50,11 +50,10 @@ deps=
 whitelist_externals =
     bash
     make
-    tee
-    mlx-warnings >= 1.2.0
+    mlx-warnings >= 1.3.1
 commands=
     bash -c 'make -C doc clean'
-    mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 --command make -C doc html
+    mlx-warnings --sphinx --exact-warnings 0 --command make -C doc html
 
 [testenv:codecov]
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*


### PR DESCRIPTION
Let's move failure messages into a literal code block so that they are not parsed as RST syntax. 

Here's an example of a failure message that caused a problem. In the below failure message `AB_` should not be treated as a reStructuredText reference.

`Length of 'bytearray(b'AB_\x00')' should be 5 but is 4.`

This resulted in the following Sphinx warning:

`WARNING: Unknown target name: "ab".`