### PR TITLE
Filter out metadata in XML input added by RobotFramework==5.0.0

### DIFF
--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -77,6 +77,8 @@ def parse_xunit_root(input_file):
     This function parses the root element of the XML file and returns a testsuites root element and the set of prefixes
     to use.
 
+    Note: only elements with tag 'testsuites', 'testsuite' and 'testcase' are included.
+
     Args:
         input_file (Path): Path to the input file (.xml).
 
@@ -93,6 +95,14 @@ def parse_xunit_root(input_file):
     else:
         test_suites = root_input
         prefix_set = UTEST
+
+    for suite in test_suites:
+        if suite.tag != 'testsuite':
+            test_suites.remove(suite)
+            continue
+        for test in suite:
+            if test.tag != 'testcase':
+                suite.remove(test)
 
     return test_suites, prefix_set
 

--- a/tests/test_in/itest_report.xml
+++ b/tests/test_in/itest_report.xml
@@ -7,4 +7,9 @@
 </testcase>
 <testcase classname="Example" name="Another test" time="0.002">
 </testcase>
+<properties>
+    <property name="Documentation" value="My test suite title" />
+    <property name="More Info" value="Test support for xUnit output of RobotFramework==5.0.0" />
+    <property name="Version" value="1.0" />
+</properties>
 </testsuite>

--- a/tests/test_in/qtest_my_lib_report.xml
+++ b/tests/test_in/qtest_my_lib_report.xml
@@ -15,4 +15,9 @@
             <failure message="File: ./qualification_test/my_functions.c&#10;Line: 49&#10;Message: exp &quot;12 34 56 &quot; was &quot;12 34 99 &quot;&#10;" />
         </testcase>
     </testsuite>
+    <properties>
+        <property name="Documentation" value="My test suite title" />
+        <property name="More Info" value="Test compatibility with a 'properties' element thrown in" />
+        <property name="Version" value="1.0" />
+    </properties>
 </testsuites>


### PR DESCRIPTION
[RobotFramework==5.0.0](https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-5.0.rst) adds a a lot of new features. For example, it adds metadata to its xUnit output, as discussed in [this issue](https://github.com/robotframework/robotframework/issues/4199). 

The changes in this PR are needed so that mlx.xunit2rst doesn't treat this metadata as a test suite, which results in `KeyError: 'name'`.

Resolves #32 