### PR TITLE
Include skipped tests in the item-matrix

### DIFF
--- a/mlx/xunit2rst.mako
+++ b/mlx/xunit2rst.mako
@@ -110,7 +110,7 @@ The below table traces the test report to test cases.
     :target: ${prefix}
     :sourcetitle: ${info.type.capitalize()} test report
     :targettitle: ${info.type.capitalize()} test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/itest_as_utest_report.rst
+++ b/tests/test_in/itest_as_utest_report.rst
@@ -38,7 +38,7 @@ The below table traces the test report to test cases.
     :target: ITEST-
     :sourcetitle: Unit test report
     :targettitle: Unit test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/itest_lin_report.rst
+++ b/tests/test_in/itest_lin_report.rst
@@ -38,7 +38,7 @@ The below table traces the test report to test cases.
     :target: ITEST_LIN-
     :sourcetitle: Integration test report
     :targettitle: Integration test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/itest_lin_report_failures.rst
+++ b/tests/test_in/itest_lin_report_failures.rst
@@ -44,7 +44,7 @@ The below table traces the test report to test cases.
     :target: ITEST-
     :sourcetitle: Integration test report
     :targettitle: Integration test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/itest_report.rst
+++ b/tests/test_in/itest_report.rst
@@ -38,7 +38,7 @@ The below table traces the test report to test cases.
     :target: ITEST-
     :sourcetitle: Integration test report
     :targettitle: Integration test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/itest_report_log.rst
+++ b/tests/test_in/itest_report_log.rst
@@ -39,7 +39,7 @@ The below table traces the test report to test cases.
     :target: ITEST-
     :sourcetitle: Integration test report
     :targettitle: Integration test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/itest_report_log_links.rst
+++ b/tests/test_in/itest_report_log_links.rst
@@ -42,7 +42,7 @@ The below table traces the test report to test cases.
     :target: ITEST-
     :sourcetitle: Integration test report
     :targettitle: Integration test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/itest_report_log_links_multisuite.rst
+++ b/tests/test_in/itest_report_log_links_multisuite.rst
@@ -114,7 +114,7 @@ The below table traces the test report to test cases.
     :target: ITEST-
     :sourcetitle: Integration test report
     :targettitle: Integration test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/itest_report_skipped_failures_log.rst
+++ b/tests/test_in/itest_report_skipped_failures_log.rst
@@ -46,7 +46,7 @@ The below table traces the test report to test cases.
     :target: ITEST-
     :sourcetitle: Integration test report
     :targettitle: Integration test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/qtest_my_lib_report.rst
+++ b/tests/test_in/qtest_my_lib_report.rst
@@ -43,7 +43,7 @@ The below table traces the test report to test cases.
     :target: QTEST_MY_LIB-
     :sourcetitle: Qualification test report
     :targettitle: Qualification test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/utest_my_lib_report.rst
+++ b/tests/test_in/utest_my_lib_report.rst
@@ -43,7 +43,7 @@ The below table traces the test report to test cases.
     :target: UTEST_MY_LIB-
     :sourcetitle: Unit test report
     :targettitle: Unit test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/utest_my_lib_report_failures.rst
+++ b/tests/test_in/utest_my_lib_report_failures.rst
@@ -49,7 +49,7 @@ The below table traces the test report to test cases.
     :target: UTEST-
     :sourcetitle: Unit test report
     :targettitle: Unit test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/utest_my_lib_report_skipped.rst
+++ b/tests/test_in/utest_my_lib_report_skipped.rst
@@ -48,7 +48,7 @@ The below table traces the test report to test cases.
     :target: UTEST_MY_LIB-
     :sourcetitle: Unit test report
     :targettitle: Unit test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/utest_my_lib_suites_report.rst
+++ b/tests/test_in/utest_my_lib_suites_report.rst
@@ -38,7 +38,7 @@ The below table traces the test report to test cases.
     :target: UTEST_MY_LIB-
     :sourcetitle: Unit test report
     :targettitle: Unit test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/utest_my_lib_suites_report_skipped.rst
+++ b/tests/test_in/utest_my_lib_suites_report_skipped.rst
@@ -48,7 +48,7 @@ The below table traces the test report to test cases.
     :target: UTEST_MY_LIB-
     :sourcetitle: Unit test report
     :targettitle: Unit test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:

--- a/tests/test_in/utest_override_prefix_report.rst
+++ b/tests/test_in/utest_override_prefix_report.rst
@@ -43,7 +43,7 @@ The below table traces the test report to test cases.
     :target: OVERRIDING-
     :sourcetitle: Unit test report
     :targettitle: Unit test specification
-    :type: fails passes
+    :type: fails passes skipped
     :stats:
     :group: top
     :nocaptions:


### PR DESCRIPTION
Completes #34, which was released in 1.2.0. Let's release bugfix in 1.2.1.