### PR TITLE
Support exclusion of the RST output based on tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,9 +60,10 @@ Usage
 
     mlx.xunit2rst --help
 
-    usage: xunit2rst [-h] -i INPUT_FILE -o RST_OUTPUT_FILE [-s] [-p PREFIX]
-                     [--trim-suffix] [--unit-or-integration UNIT_OR_INTEGRATION]
-                     [-t TYPE] [-f] [-l LOG] [--links] [-v]
+    usage: xunit2rst [-h] -i INPUT_FILE -o RST_OUTPUT_FILE [--only EXPRESSION] [-s] [-p PREFIX]
+                     [--trim-suffix] [--unit-or-integration UNIT_OR_INTEGRATION] [-t TYPE] [-f]
+                     [-l LOG] [--links] [-v]
+
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -70,6 +71,8 @@ Usage
                             The input XML file
       -o RST_OUTPUT_FILE, --output RST_OUTPUT_FILE
                             The output RST file
+      --only EXPRESSION     Expression of tags for Sphinx' `only` directive that surrounds all
+                            RST content. By default, no `only` directive is generated.
       -s, --itemize-suites  Flag to itemize testsuite elements instead of testcase
                             elements.
       -p PREFIX, --prefix PREFIX
@@ -91,7 +94,13 @@ Usage
                             for each test case as ext_robotframeworklog link id.
       -v, --version         show program's version number and exit
 
+If you use the ``--only`` input argument, you should also add |sphinx_selective_exclude.eager_only|_ to the
+``extensions`` list to prevent `mlx.traceability`_ from parsing the content and ignoring the effect of the
+``only`` directive.
+
 .. _`mlx.traceability`: https://pypi.org/project/mlx.traceability/
+.. |sphinx_selective_exclude.eager_only| replace:: ``'sphinx_selective_exclude.eager_only'``
+.. _sphinx_selective_exclude.eager_only: https://pypi.org/project/sphinx-selective-exclude/
 
 --------
 Behavior

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,7 @@ CP            := cp
 ROBOT_XUNIT   = $(ROBOTDIR)/report.xml
 ITEST_PLAN    = $(OUTDIR)/itest_plan.rst
 LOG_FILE      = log.html
-LAYER         ?= FLASH
+LAYER         ?= ""
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,6 +20,7 @@ CP            := cp
 ROBOT_XUNIT   = $(ROBOTDIR)/report.xml
 ITEST_PLAN    = $(OUTDIR)/itest_plan.rst
 LOG_FILE      = log.html
+LAYER         ?= FLASH
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -37,7 +38,7 @@ html: Makefile
 	@$(RM) $(ITEST_PLAN)
 	-@$(ROBOT) --xunit report.xml -d $(ROBOTDIR) $(ROBOTDIR)/example.robot
 	@$(XUNIT2RST) -v
-	@$(XUNIT2RST) -i $(ROBOT_XUNIT) -o $(OUTDIR)/itest_report.rst -p ITEST_- --trim-suffix -l ../$(LOG_FILE) --links --failure-message
+	@$(XUNIT2RST) -i $(ROBOT_XUNIT) -o $(OUTDIR)/itest_report.rst -p ITEST_- --trim-suffix -l ../$(LOG_FILE) --only $(LAYER) --links --failure-message
 	@$(ROBOT2RST) --robot $(ROBOTDIR)/example.robot --rst $(ITEST_PLAN) --tags ^RQT-$
 	@$(ECHO) -n $(LOG_FILE) | xargs -d ' ' -n 1 -I {} $(CP) $(ROBOTDIR)/{} $(OUTDIR)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,6 +51,7 @@ texinfo_documents = [
 # ones.
 extensions = [
     'mlx.traceability',
+    'sphinx_selective_exclude.eager_only',
 ]
 
 # This is the location where we copy the log file to. It is relative to Sphinx'
@@ -118,4 +119,5 @@ html_static_path = [os.path.join(os.path.dirname(mlx.traceability.__file__), 'as
 traceability_render_relationship_per_item = True
 
 def setup(app):
-    pass
+    if os.environ.get('LAYER', 'FLASH') == 'FLASH':
+        tags.add('FLASH')

--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -4,9 +4,9 @@ import logging
 import xml.etree.ElementTree as ET
 from collections import namedtuple
 from pathlib import Path
+from textwrap import indent
 
 from mako.exceptions import RichTraceback
-from mako.runtime import Context
 from mako.template import Template
 from pkg_resources import DistributionNotFound, require
 
@@ -17,11 +17,12 @@ QTEST = TraceableInfo('QTEST_', 'qualification', '_qualification_test_report_')
 TEMPLATE_FILE = Path(__file__).parent.joinpath('xunit2rst.mako')
 
 
-def render_template(destination, **kwargs):
+def render_template(destination, only="", **kwargs):
     """ Renders the Mako template, and writes output file to the specified destination.
 
     Args:
         destination (Path): Location of the output file.
+        only (str): Expression for 'only' directive, which will only be added when this string is not empty.
         **kwargs (dict): Variables to be used in the Mako template.
 
     Raises:
@@ -29,18 +30,22 @@ def render_template(destination, **kwargs):
         Exception: Re-raised Exception coming from Mako template.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with open(str(destination), 'w', newline='\n', encoding='utf-8') as rst_file:
-        template = Template(filename=str(TEMPLATE_FILE), output_encoding='utf-8', input_encoding='utf-8')
-        try:
-            template.render_context(Context(rst_file, **kwargs))
-        except Exception as exc:
-            traceback = RichTraceback()
-            logging.error("Exception raised in Mako template, which will be re-raised after logging line info:")
-            logging.error("File %s, line %s, in %s: %r", *traceback.traceback[-1])
-            raise exc
+    template = Template(filename=str(TEMPLATE_FILE))
+    try:
+        rst_content = template.render(**kwargs)
+    except Exception as exc:
+        traceback = RichTraceback()
+        logging.error("Exception raised in Mako template, which will be re-raised after logging line info:")
+        logging.error("File %s, line %s, in %s: %r", *traceback.traceback[-1])
+        raise exc
+    if only:
+        rst_content = f".. only:: {only}\n\n{indent(rst_content, ' ' * 4)}"
+    with open(str(destination), 'w', encoding='utf-8', newline='\n') as rst_file:
+        rst_file.write(rst_content)
 
 
-def generate_xunit_to_rst(input_file, rst_file, itemize_suites, failure_message, log_file, add_links, *prefix_args):
+def generate_xunit_to_rst(input_file, rst_file, itemize_suites, failure_message, log_file, add_links, *prefix_args,
+                          **kwargs):
     """ Processes input arguments, calls mako template function while passing all needed parameters.
 
     Args:
@@ -69,6 +74,7 @@ def generate_xunit_to_rst(input_file, rst_file, itemize_suites, failure_message,
         failure_message=failure_message,
         log_file=log_file,
         add_links=add_links,
+        **kwargs,
     )
 
 
@@ -198,6 +204,9 @@ def create_parser():
                             dest='rst_output_file',
                             type=Path,
                             help='The output RST file')
+    arg_parser.add_argument("--only", dest="expression", default="",
+                            help="Expression of tags for Sphinx' `only` directive that surrounds all RST content. "
+                            "By default, no `only` directive is generated.")
     arg_parser.add_argument('-s', '--itemize-suites',
                             action='store_true',
                             help="Flag to itemize testsuite elements instead of testcase elements.")
@@ -243,6 +252,7 @@ def main():
         args.prefix,
         args.trim_suffix,
         args.type,
+        only=args.expression,
     )
 
 

--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -166,7 +166,7 @@ def verify_prefix_set(prefix_set, prefix, type_):
         TraceableInfo: namedtuple that contains prefix and other info regarding the type of test
 
     Raises:
-        ValueError: The unit-or-integration argument is used, but is invalid.
+        ValueError: The --type argument is used, but is invalid.
     """
     type_map = {
         'u': UTEST,

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps=
     sphinx_rtd_theme
     mlx.traceability >= 4.3.2
     mlx.warnings >= 1.2.0
-    mlx.robot2rst >= 2.0.2
+    mlx.robot2rst >= 2.0.2, <3
     robotframework >= 5.0.1
     sphinx_selective_exclude >= 1.0.3
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ whitelist_externals =
     mlx-warnings >= 1.3.1
 commands=
     bash -c 'make -C doc clean'
+    mlx-warnings --sphinx --exact-warnings 6 --command make -C doc html LAYER=ROM
     mlx-warnings --sphinx --exact-warnings 0 --command make -C doc html
 
 [testenv:codecov]

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps=
     mlx.warnings >= 1.2.0
     mlx.robot2rst >= 2.0.2
     robotframework >= 5.0.1
+    sphinx_selective_exclude >= 1.0.3
 whitelist_externals =
     bash
     make

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ commands=
     bash -c 'make -C doc clean'
     mlx-warnings --sphinx --exact-warnings 6 --command make -C doc html LAYER=ROM
     mlx-warnings --sphinx --exact-warnings 0 --command make -C doc html
+    mlx-warnings --sphinx --exact-warnings 0 --command make -C doc html LAYER=FLASH
 
 [testenv:codecov]
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*


### PR DESCRIPTION
Added a new optional input argument `--only EXPRESSION` to exclude the entire content of the RST file from the documentation, provided that the extension [sphinx-selective-exclude.eager_only](https://pypi.org/project/sphinx-selective-exclude/) is used.

The `EXPRESSION` exists of one or more tags and is explained in more detail in [Sphinx' documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#including-content-based-on-tags).