### PR TITLE
Support Robot Framework v5

### DIFF
--- a/mlx/xunit2rst.mako
+++ b/mlx/xunit2rst.mako
@@ -49,7 +49,8 @@ Test Reports
 suite_names = set()
 test_idx = 0
 %>
-% for suite_idx, suite in enumerate(test_suites, start=1):
+% for suite_idx, suite in enumerate(test_suites):
+<% print(suite_idx); extra_content_map = indexed_extra_content_map.get(suite_idx, {}) %>\
     % if not itemize_suites:  # create traceable item per testcase element
         % for test in suite:
 <%
@@ -72,7 +73,7 @@ if add_links:
         suite_names.add(suite_name)
 test_idx += 1
 %>\
-${generate_item(test.attrib['name'], relationship, failure_message, [test], (len(suite_names), test_idx))}\
+${generate_item(test.attrib['name'], relationship, failure_message, [test], (len(suite_names), test_idx), extra_content_map)}\
         % endfor
     % else:  # create traceable item per testsuite element
 <%
@@ -95,7 +96,7 @@ else:
         test_result = 'Skip'
         relationship = 'skipped'
 %>\
-${generate_item(suite.attrib['name'], relationship, failure_message, suite, (0, suite_idx))}\
+${generate_item(suite.attrib['name'], relationship, failure_message, suite, (0, suite_idx + 1), extra_content_map)}\
     % endif
 % endfor
 Traceability Matrix
@@ -113,7 +114,7 @@ The below table traces the test report to test cases.
     :group: top
     :nocaptions:
 \
-<%def name="generate_item(element_name, relationship, failure_msg, tests, indexes)">\
+<%def name="generate_item(element_name, relationship, failure_msg, tests, indexes, extra_content_map)">\
 <%
 test_name = _convert_name(element_name)
 key_name = element_name.lower().replace(' ', '_')

--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -171,7 +171,7 @@ def build_prefix_and_set(test_suites, prefix_set, prefix, trim_suffix, type_):
         test_suite = list(test_suites)[-1]
         test_suite_name = test_suite.attrib.get('name', '')
         name_parts = test_suite_name.split('.')[-1].split('-')
-        if len(name_parts) > 1 :
+        if len(name_parts) > 1:
             prefix = name_parts[0] + '-'
         else:  # test suite has no name or does not contain a prefix
             prefix = prefix_set.matrix_prefix

--- a/mlx/xunit2rst.py
+++ b/mlx/xunit2rst.py
@@ -72,7 +72,7 @@ def generate_xunit_to_rst(input_file, rst_file, itemize_suites, failure_message,
         if not file.is_absolute():
             file = input_file.parent / file
         extra_content_map = {name.lower().replace(' ', '_'): content
-                            for name, content in yaml.load(file).items()}
+                             for name, content in yaml.load(file).items()}
         indexed_extra_content_map[i] = extra_content_map
 
     render_template(

--- a/tests/acceptance_test.py
+++ b/tests/acceptance_test.py
@@ -287,6 +287,27 @@ class TestAcceptance(unittest.TestCase):
         reference_rst = str(TEST_IN_DIR / rst_file_name)
         assert filecmp.cmp(output_rst, reference_rst)
 
+    def test_xunit_rf6(self):
+        file_name = 'rf6_report'
+        rst_file_name = '{}.rst'.format(file_name)
+        xml_file_name = '{}.xml'.format(file_name)
+        input_xml = str(TEST_IN_DIR / xml_file_name)
+        output_rst = str(TEST_OUT_DIR / rst_file_name)
+        xunit2rst_check(input_xml, output_rst, log_file='log.html', add_links=True)
+        reference_rst = str(TEST_IN_DIR / rst_file_name)
+        assert filecmp.cmp(output_rst, reference_rst)
+
+    def test_xunit_rf6_multisuite(self):
+        file_name = 'rf6_multisuite_report'
+        rst_file_name = '{}.rst'.format(file_name)
+        xml_file_name = '{}.xml'.format(file_name)
+        input_xml = str(TEST_IN_DIR / xml_file_name)
+        output_rst = str(TEST_OUT_DIR / rst_file_name)
+        xunit2rst_check(input_xml, output_rst, type_='q', prefix='SWQTEST-', log_file='log.html', add_links=True)
+
+        reference_rst = str(TEST_IN_DIR / rst_file_name)
+        assert filecmp.cmp(output_rst, reference_rst)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/mako_test.py
+++ b/tests/mako_test.py
@@ -27,7 +27,7 @@ class TestMako(unittest.TestCase):
                            log_cm.output[0])
         test_case.assertIn('File ', log_cm.output[-1])
         test_case.assertIn('line ', log_cm.output[-1])
-        test_case.assertIn("in render_body: '% for suite_idx, suite in enumerate(test_suites, start=1):'",
+        test_case.assertIn("in render_body: '% for suite_idx, suite in enumerate(test_suites):'",
                            log_cm.output[-1])
 
 

--- a/tests/prefix_test.py
+++ b/tests/prefix_test.py
@@ -68,10 +68,16 @@ class TestPrefix(unittest.TestCase):
         self.assertEqual(prefix_set, ITEST)
         self.assertEqual(prefix, 'UTEST_HOWDY-')
 
-    def test_content_file_path(self):
-        ''' Argument --type must have the highest priority for determining the correct prefix_set. '''
-        _, _, content_file_path = parse_xunit_root(TEST_IN_DIR / 'qtest_my_lib_report.xml')
-        self.assertEqual(content_file_path, {3: Path("../../doc/source/extra_content.yml")})
+    def test_content_files(self):
+        ''' Test the extraction of the content file path '''
+        _, _, content_files = parse_xunit_root(TEST_IN_DIR / 'qtest_my_lib_report.xml')
+        self.assertEqual(content_files, {3: Path("../../doc/source/extra_content.yml")})
+
+
+    def test_content_files_no_root(self):
+        ''' Test the extraction of the content file path when the XML has no valid root element '''
+        _, _, content_files = parse_xunit_root(TEST_IN_DIR / 'itest_report.xml')
+        self.assertEqual(content_files, {0: Path('./extra_content1.yml')})
 
     def test_verify_prefix_set(self):
         '''

--- a/tests/prefix_test.py
+++ b/tests/prefix_test.py
@@ -73,7 +73,6 @@ class TestPrefix(unittest.TestCase):
         _, _, content_files = parse_xunit_root(TEST_IN_DIR / 'qtest_my_lib_report.xml')
         self.assertEqual(content_files, {3: Path("../../doc/source/extra_content.yml")})
 
-
     def test_content_files_no_root(self):
         ''' Test the extraction of the content file path when the XML has no valid root element '''
         _, _, content_files = parse_xunit_root(TEST_IN_DIR / 'itest_report.xml')

--- a/tests/prefix_test.py
+++ b/tests/prefix_test.py
@@ -71,7 +71,7 @@ class TestPrefix(unittest.TestCase):
     def test_content_file_path(self):
         ''' Argument --type must have the highest priority for determining the correct prefix_set. '''
         _, _, content_file_path = parse_xunit_root(TEST_IN_DIR / 'qtest_my_lib_report.xml')
-        self.assertEqual(content_file_path, Path("../../doc/source/extra_content.yml"))
+        self.assertEqual(content_file_path, {3: Path("../../doc/source/extra_content.yml")})
 
     def test_verify_prefix_set(self):
         '''

--- a/tests/test_in/extra_content0.yml
+++ b/tests/test_in/extra_content0.yml
@@ -1,0 +1,1 @@
+closed_loop motor control: closed loop motor control extra content

--- a/tests/test_in/extra_content1.yml
+++ b/tests/test_in/extra_content1.yml
@@ -1,0 +1,2 @@
+blocked motor blocked: blocked motor blocked extra content
+motor stop with fixed braking time: motor stop with fixed braking time extra content

--- a/tests/test_in/itest_report.xml
+++ b/tests/test_in/itest_report.xml
@@ -11,5 +11,6 @@
     <property name="Documentation" value="My test suite title" />
     <property name="More Info" value="Test support for xUnit output of RobotFramework==5.0.0" />
     <property name="Version" value="1.0" />
+    <property name="xUnit2rst Content File" value="./extra_content1.yml" />
 </properties>
 </testsuite>

--- a/tests/test_in/qtest_my_lib_report.xml
+++ b/tests/test_in/qtest_my_lib_report.xml
@@ -14,11 +14,12 @@
         <testcase classname="MY_LIB.QTEST_MY_LIB-SOME_FUNCTION" name="QTEST_MY_LIB-SOME_FUNCTION" time="0.0">
             <failure message="File: ./qualification_test/my_functions.c&#10;Line: 49&#10;Message: exp &quot;12 34 56 &quot; was &quot;12 34 99 &quot;&#10;" />
         </testcase>
-    </testsuite>
+
     <properties>
         <property name="Documentation" value="My test suite title" />
         <property name="More Info" value="Test compatibility with a 'properties' element thrown in" />
         <property name="xUnit2rst Content File" value="../../doc/source/extra_content.yml" />
         <property name="Version" value="1.0" />
     </properties>
+    </testsuite>
 </testsuites>

--- a/tests/test_in/rf6_multisuite_report.rst
+++ b/tests/test_in/rf6_multisuite_report.rst
@@ -20,6 +20,8 @@ Test Reports
 
     Test result: Pass
 
+    closed loop motor control extra content
+
 .. item:: REPORT_SWQTEST-CLOSED_LOOP_SLEW_RATE Test report for SWQTEST-CLOSED_LOOP_SLEW_RATE
     :passes: SWQTEST-CLOSED_LOOP_SLEW_RATE
     :ext_robotframeworklog: log.html:s1-t2
@@ -31,6 +33,8 @@ Test Reports
     :ext_robotframeworklog: log.html:s1-t3
 
     Test result: Pass
+
+    blocked motor blocked extra content
 
 .. item:: REPORT_SWQTEST-MOTOR_START_WITH_FIXED_BRAKING_TIME Test report for SWQTEST-MOTOR_START_WITH_FIXED_BRAKING_TIME
     :passes: SWQTEST-MOTOR_START_WITH_FIXED_BRAKING_TIME
@@ -44,6 +48,8 @@ Test Reports
 
     Test result: Pass
 
+    motor stop with fixed braking time extra content
+
 .. item:: REPORT_SWQTEST-OPEN_LOOP_MOTOR_CONTROL Test report for SWQTEST-OPEN_LOOP_MOTOR_CONTROL
     :passes: SWQTEST-OPEN_LOOP_MOTOR_CONTROL
     :ext_robotframeworklog: log.html:s1-t6
@@ -53,66 +59,6 @@ Test Reports
 .. item:: REPORT_SWQTEST-OPEN_LOOP_SLEW_RATE Test report for SWQTEST-OPEN_LOOP_SLEW_RATE
     :passes: SWQTEST-OPEN_LOOP_SLEW_RATE
     :ext_robotframeworklog: log.html:s1-t7
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-PI_LOOP_ASYMMETRIC_KI_COEFF Test report for SWQTEST-PI_LOOP_ASYMMETRIC_KI_COEFF
-    :passes: SWQTEST-PI_LOOP_ASYMMETRIC_KI_COEFF
-    :ext_robotframeworklog: log.html:s1-t8
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-PI_LOOP_ASYMMETRIC_KP_COEFF Test report for SWQTEST-PI_LOOP_ASYMMETRIC_KP_COEFF
-    :passes: SWQTEST-PI_LOOP_ASYMMETRIC_KP_COEFF
-    :ext_robotframeworklog: log.html:s1-t9
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-PI_LOOP_ASYMMETRIC_FACTOR Test report for SWQTEST-PI_LOOP_ASYMMETRIC_FACTOR
-    :passes: SWQTEST-PI_LOOP_ASYMMETRIC_FACTOR
-    :ext_robotframeworklog: log.html:s1-t10
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-PULSE_TRAIN_PULSE_DELAY Test report for SWQTEST-PULSE_TRAIN_PULSE_DELAY
-    :passes: SWQTEST-PULSE_TRAIN_PULSE_DELAY
-    :ext_robotframeworklog: log.html:s1-t11
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-PULSE_TRAIN_OUTPUT_DUTY_CYCLE Test report for SWQTEST-PULSE_TRAIN_OUTPUT_DUTY_CYCLE
-    :passes: SWQTEST-PULSE_TRAIN_OUTPUT_DUTY_CYCLE
-    :ext_robotframeworklog: log.html:s1-t12
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-PULSE_TRAIN_HALF_FLAT_NON_FLAT Test report for SWQTEST-PULSE_TRAIN_HALF_FLAT_NON_FLAT
-    :passes: SWQTEST-PULSE_TRAIN_HALF_FLAT_NON_FLAT
-    :ext_robotframeworklog: log.html:s1-t13
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-WINDMILLING_CHECK Test report for SWQTEST-WINDMILLING_CHECK
-    :passes: SWQTEST-WINDMILLING_CHECK
-    :ext_robotframeworklog: log.html:s1-t14
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITHOUT_BRAKING Test report for SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITHOUT_BRAKING
-    :passes: SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITHOUT_BRAKING
-    :ext_robotframeworklog: log.html:s1-t15
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITH_BRAKING Test report for SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITH_BRAKING
-    :passes: SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITH_BRAKING
-    :ext_robotframeworklog: log.html:s1-t16
-
-    Test result: Pass
-
-.. item:: REPORT_SWQTEST-FORWARD_WINDMILLING_DETECTED Test report for SWQTEST-FORWARD_WINDMILLING_DETECTED
-    :passes: SWQTEST-FORWARD_WINDMILLING_DETECTED
-    :ext_robotframeworklog: log.html:s1-t17
 
     Test result: Pass
 

--- a/tests/test_in/rf6_multisuite_report.rst
+++ b/tests/test_in/rf6_multisuite_report.rst
@@ -1,0 +1,132 @@
+.. _qualification_test_report_rf6_multisuite:
+
+============================================
+Qualification Test Report for rf6_multisuite
+============================================
+
+The log file that contains details about the executed test cases can be found `here <log.html>`_.
+
+.. contents:: `Contents`
+    :depth: 2
+    :local:
+
+
+Test Reports
+============
+
+.. item:: REPORT_SWQTEST-CLOSED_LOOP_MOTOR_CONTROL Test report for SWQTEST-CLOSED_LOOP_MOTOR_CONTROL
+    :passes: SWQTEST-CLOSED_LOOP_MOTOR_CONTROL
+    :ext_robotframeworklog: log.html:s1-t1
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-CLOSED_LOOP_SLEW_RATE Test report for SWQTEST-CLOSED_LOOP_SLEW_RATE
+    :passes: SWQTEST-CLOSED_LOOP_SLEW_RATE
+    :ext_robotframeworklog: log.html:s1-t2
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-BLOCKED_MOTOR_BLOCKED Test report for SWQTEST-BLOCKED_MOTOR_BLOCKED
+    :passes: SWQTEST-BLOCKED_MOTOR_BLOCKED
+    :ext_robotframeworklog: log.html:s1-t3
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-MOTOR_START_WITH_FIXED_BRAKING_TIME Test report for SWQTEST-MOTOR_START_WITH_FIXED_BRAKING_TIME
+    :passes: SWQTEST-MOTOR_START_WITH_FIXED_BRAKING_TIME
+    :ext_robotframeworklog: log.html:s1-t4
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-MOTOR_STOP_WITH_FIXED_BRAKING_TIME Test report for SWQTEST-MOTOR_STOP_WITH_FIXED_BRAKING_TIME
+    :passes: SWQTEST-MOTOR_STOP_WITH_FIXED_BRAKING_TIME
+    :ext_robotframeworklog: log.html:s1-t5
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-OPEN_LOOP_MOTOR_CONTROL Test report for SWQTEST-OPEN_LOOP_MOTOR_CONTROL
+    :passes: SWQTEST-OPEN_LOOP_MOTOR_CONTROL
+    :ext_robotframeworklog: log.html:s1-t6
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-OPEN_LOOP_SLEW_RATE Test report for SWQTEST-OPEN_LOOP_SLEW_RATE
+    :passes: SWQTEST-OPEN_LOOP_SLEW_RATE
+    :ext_robotframeworklog: log.html:s1-t7
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-PI_LOOP_ASYMMETRIC_KI_COEFF Test report for SWQTEST-PI_LOOP_ASYMMETRIC_KI_COEFF
+    :passes: SWQTEST-PI_LOOP_ASYMMETRIC_KI_COEFF
+    :ext_robotframeworklog: log.html:s1-t8
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-PI_LOOP_ASYMMETRIC_KP_COEFF Test report for SWQTEST-PI_LOOP_ASYMMETRIC_KP_COEFF
+    :passes: SWQTEST-PI_LOOP_ASYMMETRIC_KP_COEFF
+    :ext_robotframeworklog: log.html:s1-t9
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-PI_LOOP_ASYMMETRIC_FACTOR Test report for SWQTEST-PI_LOOP_ASYMMETRIC_FACTOR
+    :passes: SWQTEST-PI_LOOP_ASYMMETRIC_FACTOR
+    :ext_robotframeworklog: log.html:s1-t10
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-PULSE_TRAIN_PULSE_DELAY Test report for SWQTEST-PULSE_TRAIN_PULSE_DELAY
+    :passes: SWQTEST-PULSE_TRAIN_PULSE_DELAY
+    :ext_robotframeworklog: log.html:s1-t11
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-PULSE_TRAIN_OUTPUT_DUTY_CYCLE Test report for SWQTEST-PULSE_TRAIN_OUTPUT_DUTY_CYCLE
+    :passes: SWQTEST-PULSE_TRAIN_OUTPUT_DUTY_CYCLE
+    :ext_robotframeworklog: log.html:s1-t12
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-PULSE_TRAIN_HALF_FLAT_NON_FLAT Test report for SWQTEST-PULSE_TRAIN_HALF_FLAT_NON_FLAT
+    :passes: SWQTEST-PULSE_TRAIN_HALF_FLAT_NON_FLAT
+    :ext_robotframeworklog: log.html:s1-t13
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-WINDMILLING_CHECK Test report for SWQTEST-WINDMILLING_CHECK
+    :passes: SWQTEST-WINDMILLING_CHECK
+    :ext_robotframeworklog: log.html:s1-t14
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITHOUT_BRAKING Test report for SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITHOUT_BRAKING
+    :passes: SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITHOUT_BRAKING
+    :ext_robotframeworklog: log.html:s1-t15
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITH_BRAKING Test report for SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITH_BRAKING
+    :passes: SWQTEST-FORWARD_WINDMILLING_NO_MOVEMENT_DETECTED_WITH_BRAKING
+    :ext_robotframeworklog: log.html:s1-t16
+
+    Test result: Pass
+
+.. item:: REPORT_SWQTEST-FORWARD_WINDMILLING_DETECTED Test report for SWQTEST-FORWARD_WINDMILLING_DETECTED
+    :passes: SWQTEST-FORWARD_WINDMILLING_DETECTED
+    :ext_robotframeworklog: log.html:s1-t17
+
+    Test result: Pass
+
+Traceability Matrix
+===================
+
+The below table traces the test report to test cases.
+
+.. item-matrix:: Linking these qualification test reports to qualification test cases
+    :source: REPORT_SWQTEST-
+    :target: SWQTEST-
+    :sourcetitle: Qualification test report
+    :targettitle: Qualification test specification
+    :type: fails passes skipped
+    :stats:
+    :group: top
+    :nocaptions:

--- a/tests/test_in/rf6_multisuite_report.xml
+++ b/tests/test_in/rf6_multisuite_report.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling" tests="17" errors="0" failures="0" skipped="0" time="3088.158" timestamp="2023-03-30T10:04:27.156000">
+<testsuite name="Closed Loop Control" tests="2" errors="0" failures="0" skipped="0" time="340.365" timestamp="2023-03-30T10:04:27.210000">
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Closed Loop Control" name="closed loop motor control" time="65.867">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Closed Loop Control" name="closed loop slew rate" time="256.949">
+</testcase>
+<properties>
+<property name="Documentation" value="Closed loop control testsuite"/>
+<property name="More Info" value="Motor tests with focus on closed loop control"/>
+<property name="Version" value="1.0"/>
+</properties>
+</testsuite>
+<testsuite name="Fixed Braking Time" tests="3" errors="0" failures="0" skipped="0" time="98.904" timestamp="2023-03-30T10:10:07.580000">
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Fixed Braking Time" name="blocked motor blocked" time="23.344">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Fixed Braking Time" name="motor start with fixed braking time" time="27.584">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Fixed Braking Time" name="motor stop with fixed braking time" time="33.464">
+</testcase>
+<properties>
+<property name="Documentation" value="Fixed braking time testsuite"/>
+<property name="More Info" value="Checks the SCPI commands for Javascript initialization and execution"/>
+<property name="Version" value="1.0"/>
+</properties>
+</testsuite>
+<testsuite name="Open Loop Control" tests="2" errors="0" failures="0" skipped="0" time="369.528" timestamp="2023-03-30T10:11:46.497000">
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Open Loop Control" name="open loop motor control" time="96.397">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Open Loop Control" name="open loop slew rate" time="258.676">
+</testcase>
+<properties>
+<property name="Documentation" value="Open loop control testsuite"/>
+<property name="More Info" value="Motor tests with focus on open loop control"/>
+<property name="Version" value="1.0"/>
+</properties>
+</testsuite>
+<testsuite name="Pi Loop" tests="3" errors="0" failures="0" skipped="0" time="1610.659" timestamp="2023-03-30T10:17:56.033000">
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Pi Loop" name="pi loop asymmetric KI coeff" time="640.600">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Pi Loop" name="pi loop asymmetric KP coeff" time="636.543">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Pi Loop" name="pi loop asymmetric factor" time="318.946">
+</testcase>
+<properties>
+<property name="Documentation" value="PI loop test suite"/>
+<property name="More Info" value="Motor tests with focus on PI loop control"/>
+<property name="Version" value="1.0"/>
+</properties>
+</testsuite>
+<testsuite name="Startup" tests="3" errors="0" failures="0" skipped="0" time="296.624" timestamp="2023-03-30T10:44:46.697000">
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Startup" name="pulse train pulse delay" time="56.545">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Startup" name="pulse train output duty cycle" time="117.722">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Startup" name="pulse train half flat non flat" time="107.839">
+</testcase>
+<properties>
+<property name="Documentation" value="Startup and acceleration testsuite"/>
+<property name="More Info" value="Startup and acceleration tests"/>
+<property name="Version" value="1.0"/>
+</properties>
+</testsuite>
+<testsuite name="Windmilling" tests="4" errors="0" failures="0" skipped="0" time="371.969" timestamp="2023-03-30T10:49:43.328000">
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Windmilling" name="windmilling check" time="159.289">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Windmilling" name="forward windmilling no movement detected without braking" time="92.205">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Windmilling" name="forward windmilling no movement detected with braking" time="48.452">
+</testcase>
+<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Windmilling" name="forward windmilling detected" time="57.353">
+</testcase>
+<properties>
+<property name="Documentation" value="Windmilling testsuite"/>
+<property name="More Info" value="Checks the SCPI commands for Javascript initialization and execution"/>
+<property name="Version" value="1.0"/>
+</properties>
+</testsuite>
+</testsuite>

--- a/tests/test_in/rf6_multisuite_report.xml
+++ b/tests/test_in/rf6_multisuite_report.xml
@@ -7,6 +7,7 @@
 </testcase>
 <properties>
 <property name="Documentation" value="Closed loop control testsuite"/>
+<property name="xunit2rst content file" value="./extra_content0.yml"/>
 <property name="More Info" value="Motor tests with focus on closed loop control"/>
 <property name="Version" value="1.0"/>
 </properties>
@@ -21,6 +22,7 @@
 <properties>
 <property name="Documentation" value="Fixed braking time testsuite"/>
 <property name="More Info" value="Checks the SCPI commands for Javascript initialization and execution"/>
+<property name="xunit2rst content file" value="./extra_content1.yml"/>
 <property name="Version" value="1.0"/>
 </properties>
 </testsuite>
@@ -32,47 +34,6 @@
 <properties>
 <property name="Documentation" value="Open loop control testsuite"/>
 <property name="More Info" value="Motor tests with focus on open loop control"/>
-<property name="Version" value="1.0"/>
-</properties>
-</testsuite>
-<testsuite name="Pi Loop" tests="3" errors="0" failures="0" skipped="0" time="1610.659" timestamp="2023-03-30T10:17:56.033000">
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Pi Loop" name="pi loop asymmetric KI coeff" time="640.600">
-</testcase>
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Pi Loop" name="pi loop asymmetric KP coeff" time="636.543">
-</testcase>
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Pi Loop" name="pi loop asymmetric factor" time="318.946">
-</testcase>
-<properties>
-<property name="Documentation" value="PI loop test suite"/>
-<property name="More Info" value="Motor tests with focus on PI loop control"/>
-<property name="Version" value="1.0"/>
-</properties>
-</testsuite>
-<testsuite name="Startup" tests="3" errors="0" failures="0" skipped="0" time="296.624" timestamp="2023-03-30T10:44:46.697000">
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Startup" name="pulse train pulse delay" time="56.545">
-</testcase>
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Startup" name="pulse train output duty cycle" time="117.722">
-</testcase>
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Startup" name="pulse train half flat non flat" time="107.839">
-</testcase>
-<properties>
-<property name="Documentation" value="Startup and acceleration testsuite"/>
-<property name="More Info" value="Startup and acceleration tests"/>
-<property name="Version" value="1.0"/>
-</properties>
-</testsuite>
-<testsuite name="Windmilling" tests="4" errors="0" failures="0" skipped="0" time="371.969" timestamp="2023-03-30T10:49:43.328000">
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Windmilling" name="windmilling check" time="159.289">
-</testcase>
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Windmilling" name="forward windmilling no movement detected without braking" time="92.205">
-</testcase>
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Windmilling" name="forward windmilling no movement detected with braking" time="48.452">
-</testcase>
-<testcase classname="Closed Loop Control &amp; Fixed Braking Time &amp; Open Loop Control &amp; Pi Loop &amp; Startup &amp; Windmilling.Windmilling" name="forward windmilling detected" time="57.353">
-</testcase>
-<properties>
-<property name="Documentation" value="Windmilling testsuite"/>
-<property name="More Info" value="Checks the SCPI commands for Javascript initialization and execution"/>
 <property name="Version" value="1.0"/>
 </properties>
 </testsuite>

--- a/tests/test_in/rf6_report.rst
+++ b/tests/test_in/rf6_report.rst
@@ -1,0 +1,42 @@
+.. _unit_test_report_rf6:
+
+========================
+Unit Test Report for rf6
+========================
+
+The log file that contains details about the executed test cases can be found `here <log.html>`_.
+
+.. contents:: `Contents`
+    :depth: 2
+    :local:
+
+
+Test Reports
+============
+
+.. item:: REPORT_UTEST-PI_LOOP_ASYMMETRIC_KI_COEFF Test report for UTEST-PI_LOOP_ASYMMETRIC_KI_COEFF
+    :passes: UTEST-PI_LOOP_ASYMMETRIC_KI_COEFF
+    :ext_robotframeworklog: log.html:s1-s1-t1
+
+    Test result: Pass
+
+.. item:: REPORT_UTEST-PI_LOOP_ASYMMETRIC_KP_COEFF Test report for UTEST-PI_LOOP_ASYMMETRIC_KP_COEFF
+    :passes: UTEST-PI_LOOP_ASYMMETRIC_KP_COEFF
+    :ext_robotframeworklog: log.html:s1-s1-t2
+
+    Test result: Pass
+
+Traceability Matrix
+===================
+
+The below table traces the test report to test cases.
+
+.. item-matrix:: Linking these unit test reports to unit test cases
+    :source: REPORT_UTEST-
+    :target: UTEST-
+    :sourcetitle: Unit test report
+    :targettitle: Unit test specification
+    :type: fails passes skipped
+    :stats:
+    :group: top
+    :nocaptions:

--- a/tests/test_in/rf6_report.xml
+++ b/tests/test_in/rf6_report.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Pi Loop" tests="2" errors="0" failures="0" skipped="0" time="1725.107" timestamp="2023-03-30T12:07:27.000000">
+<testsuite name="Pi Loop" tests="2" errors="0" failures="0" skipped="0" time="1724.981" timestamp="2023-03-30T12:07:27.118000">
+<testcase classname="Pi Loop.Pi Loop" name="pi loop asymmetric KI coeff" time="843.272">
+</testcase>
+<testcase classname="Pi Loop.Pi Loop" name="pi loop asymmetric KP coeff" time="837.283">
+</testcase>
+<properties>
+<property name="Documentation" value="PI loop test suite"/>
+<property name="More Info" value="Motor tests with focus on PI loop control"/>
+<property name="Version" value="1.0"/>
+</properties>
+</testsuite>
+</testsuite>


### PR DESCRIPTION
The xUnit file generated by Robot Framework v6, after executing multiple test suites (`.robot` files) combined, contains a `testsuite` element as root, which contains multiple `testsuite` children. mlx.xunit2rst only supported `testsuites` as tag of the root element, when in fact that tag name shouldn't matter.

The feature to [Add Content to Test Reports](https://melexis.github.io/xunit2rst/readme.html#add-content-to-test-reports) now supports multiple `properties` elements per input file, i.e. it can handle multiple content files for a single input file/execution.